### PR TITLE
fix(go.mod): Rename go.mod to correct repository name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,9 @@
-module github.com/researchnow/go-samplifyapi-client
+module github.com/morningconsult/go-samplifyapi-client
 
-go 1.13
+go 1.15
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
-	github.com/corpix/uarand v0.1.1 // indirect
-	github.com/etgryphon/stringUp v0.0.0-20121020160746-31534ccd8cac // indirect
-	github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428 // indirect
 	github.com/leebenson/conform v0.0.0-20190822094432-4c55492f71d7
-	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/researchnow/go-samplifyapi-client v0.0.0-20200915002704-926c0564ceb7
 )

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/ngdinhtoan/glide-cleanup v0.2.0/go.mod h1:UQzsmiDOb8YV3nOsCxK/c9zPpCZVNoHScRE3EO9pVMM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/researchnow/go-samplifyapi-client v0.0.0-20200915002704-926c0564ceb7 h1:KEPYJnx1l4l45GucubXI7ysHJqiQ+8lFQZPQ+zlabYM=
+github.com/researchnow/go-samplifyapi-client v0.0.0-20200915002704-926c0564ceb7/go.mod h1:Ge4sC1Y2XBQJOoUYJyswhIO2n3anLyOQeiTOyfkbXjk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=


### PR DESCRIPTION
*Description of Changes*

Rename the go.mod package name from `github.com/researchnow/go-samplifyapi-client` to `github.com/morningconsult/go-samplify-api-client`. Also run a `go mod tidy`.

Signed-off-by: Dilan Bellinghoven <dbellinghoven@morningconsult.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.