### PR TITLE
add context methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,23 +102,41 @@ If multiple sort objects are provided, the order in which they are added in the 
 ## Supported API functions
 
 * CreateProject(project *CreateProjectCriteria) (*ProjectResponse, error)
+* CreateProjectWithContext(ctx context.Context, project *CreateProjectCriteria) (*ProjectResponse, error)
 * UpdateProject(project *UpdateProjectCriteria) (*ProjectResponse, error)
+* UpdateProjectWithContext(ctx context.Context, project *UpdateProjectCriteria) (*ProjectResponse, error)
 * BuyProject(extProjectID string, buy []*BuyProjectCriteria) (*BuyProjectResponse, error)
+* BuyProjectWithContext(ctx context.Context, extProjectID string, buy []*BuyProjectCriteria) (*BuyProjectResponse, error)
 * CloseProject(extProjectID string) (*CloseProjectResponse, error)
+* CloseProjectWithContext(ctx context.Context, extProjectID string) (*CloseProjectResponse, error)
 * GetAllProjects(options *QueryOptions) (*GetAllProjectsResponse, error)
+* GetAllProjectsWithContext(ctx context.Context, options *QueryOptions) (*GetAllProjectsResponse, error)
 * GetProjectBy(extProjectID string) (*ProjectResponse, error)
+* GetProjectByWithContext(ctx context.Context, extProjectID string) (*ProjectResponse, error)
 * GetProjectReport(extProjectID string) (*ProjectReportResponse, error)
+* GetProjectReportWithContext(ctx context.Context, extProjectID string) (*ProjectReportResponse, error)
 * AddLineItem(extProjectID string, lineItem *CreateLineItemCriteria) (*LineItemResponse, error)
+* AddLineItemWithContext(ctx context.Context, extProjectID string, lineItem *CreateLineItemCriteria) (*LineItemResponse, error)
 * UpdateLineItem(extProjectID, extLineItemID string, lineItem *UpdateLineItemCriteria) (*LineItemResponse, error)
+* UpdateLineItemWithContext(ctx context.Context, extProjectID, extLineItemID string, lineItem *UpdateLineItemCriteria) (*LineItemResponse, error)
 * UpdateLineItemState(extProjectID, extLineItemID string, action Action) (*ChangeLineItemStateResponse, error)
+* UpdateLineItemStateWithContext(ctx context.Context, extProjectID, extLineItemID string, action Action) (*ChangeLineItemStateResponse, error)
 * GetAllLineItems(extProjectID string, options *QueryOptions) (*GetAllLineItemsResponse, error)
+* GetAllLineItemsWithContext(ctx context.Context, extProjectID string, options *QueryOptions) (*GetAllLineItemsResponse, error)
 * GetLineItemBy(extProjectID, extLineItemID string) (*LineItemResponse, error)
+* GetLineItemByWithContext(ctx context.Context, extProjectID, extLineItemID string) (*LineItemResponse, error)
 * GetFeasibility(extProjectID string, options *QueryOptions) (*GetFeasibilityResponse, error)
+* GetFeasibilityWithContext(ctx context.Context, extProjectID string, options *QueryOptions) (*GetFeasibilityResponse, error)
 * GetCountries(options *QueryOptions) (*GetCountriesResponse, error)
+* GetCountriesWithContext(ctx context.Context, options *QueryOptions) (*GetCountriesResponse, error)
 * GetAttributes(countryCode, languageCode string, options *QueryOptions) (*GetAttributesResponse, error)
+* GetAttributesWithContext(ctx context.Context, countryCode, languageCode string, options *QueryOptions) (*GetAttributesResponse, error)
 * GetSurveyTopics(options *QueryOptions) (*GetSurveyTopicsResponse, error)
+* GetSurveyTopicsWithContext(ctx context.Context, options *QueryOptions) (*GetSurveyTopicsResponse, error)
 * RefreshToken() error
+* RefreshTokenWithContext(ctx context.Context, ) error
 * Logout() error
+* LogoutWithContext(ctx context.Context, ) error
 
 
 ## Versioning

--- a/lib/client.go
+++ b/lib/client.go
@@ -1,6 +1,7 @@
 package samplify
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -55,37 +56,52 @@ type Client struct {
 	Options     *ClientOptions
 }
 
-// GetInvoicesSummary ...
-func (c *Client) GetInvoicesSummary(options *QueryOptions) (*APIResponse, error) {
+// GetInvoicesSummaryWithContext ...
+func (c *Client) GetInvoicesSummaryWithContext(ctx context.Context, options *QueryOptions) (*APIResponse, error) {
 	path := fmt.Sprintf("/projects/invoices/summary%s", query2String(options))
-	return c.request("GET", c.Options.APIBaseURL, path, nil)
+	return c.request(ctx, "GET", c.Options.APIBaseURL, path, nil)
 }
 
-// CreateProject ...
-func (c *Client) CreateProject(project *CreateProjectCriteria) (*ProjectResponse, error) {
+// GetInvoicesSummary ...
+func (c *Client) GetInvoicesSummary(options *QueryOptions) (*APIResponse, error) {
+	return c.GetInvoicesSummaryWithContext(context.Background(), options)
+}
+
+// CreateProjectWithContext ...
+func (c *Client) CreateProjectWithContext(ctx context.Context, project *CreateProjectCriteria) (*ProjectResponse, error) {
 	err := Validate(project)
 	if err != nil {
 		return nil, err
 	}
 	res := &ProjectResponse{}
-	err = c.requestAndParseResponse("POST", "/projects", project, res)
+	err = c.requestAndParseResponse(ctx, "POST", "/projects", project, res)
 	return res, err
 }
 
-// UpdateProject ...
-func (c *Client) UpdateProject(project *UpdateProjectCriteria) (*ProjectResponse, error) {
+// CreateProject ...
+func (c *Client) CreateProject(project *CreateProjectCriteria) (*ProjectResponse, error) {
+	return c.CreateProjectWithContext(context.Background(), project)
+}
+
+// UpdateProjectWithContext ...
+func (c *Client) UpdateProjectWithContext(ctx context.Context, project *UpdateProjectCriteria) (*ProjectResponse, error) {
 	err := Validate(project)
 	if err != nil {
 		return nil, err
 	}
 	res := &ProjectResponse{}
 	path := fmt.Sprintf("/projects/%s", project.ExtProjectID)
-	err = c.requestAndParseResponse("POST", path, project, res)
+	err = c.requestAndParseResponse(ctx, "POST", path, project, res)
 	return res, err
 }
 
-// BuyProject ...
-func (c *Client) BuyProject(extProjectID string, buy []*BuyProjectCriteria) (*BuyProjectResponse, error) {
+// UpdateProject ...
+func (c *Client) UpdateProject(project *UpdateProjectCriteria) (*ProjectResponse, error) {
+	return c.UpdateProjectWithContext(context.Background(), project)
+}
+
+// BuyProjectWithContext ...
+func (c *Client) BuyProjectWithContext(ctx context.Context, extProjectID string, buy []*BuyProjectCriteria) (*BuyProjectResponse, error) {
 	err := ValidateNotEmpty(extProjectID)
 	if err != nil {
 		return nil, err
@@ -96,57 +112,82 @@ func (c *Client) BuyProject(extProjectID string, buy []*BuyProjectCriteria) (*Bu
 	}
 	res := &BuyProjectResponse{}
 	path := fmt.Sprintf("/projects/%s/buy", extProjectID)
-	err = c.requestAndParseResponse("POST", path, buy, res)
+	err = c.requestAndParseResponse(ctx, "POST", path, buy, res)
 	return res, err
 }
 
-// CloseProject ...
-func (c *Client) CloseProject(extProjectID string) (*CloseProjectResponse, error) {
+// BuyProject ...
+func (c *Client) BuyProject(extProjectID string, buy []*BuyProjectCriteria) (*BuyProjectResponse, error) {
+	return c.BuyProjectWithContext(context.Background(), extProjectID, buy)
+}
+
+// CloseProjectWithContext ...
+func (c *Client) CloseProjectWithContext(ctx context.Context, extProjectID string) (*CloseProjectResponse, error) {
 	err := ValidateNotEmpty(extProjectID)
 	if err != nil {
 		return nil, err
 	}
 	res := &CloseProjectResponse{}
 	path := fmt.Sprintf("/projects/%s/close", extProjectID)
-	err = c.requestAndParseResponse("POST", path, nil, res)
+	err = c.requestAndParseResponse(ctx, "POST", path, nil, res)
+	return res, err
+}
+
+// CloseProject ...
+func (c *Client) CloseProject(extProjectID string) (*CloseProjectResponse, error) {
+	return c.CloseProjectWithContext(context.Background(), extProjectID)
+}
+
+// GetAllProjectsWithContext ...
+func (c *Client) GetAllProjectsWithContext(ctx context.Context, options *QueryOptions) (*GetAllProjectsResponse, error) {
+	res := &GetAllProjectsResponse{}
+	query := query2String(options)
+	path := fmt.Sprintf("/projects%s", query)
+	err := c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
 // GetAllProjects ...
 func (c *Client) GetAllProjects(options *QueryOptions) (*GetAllProjectsResponse, error) {
-	res := &GetAllProjectsResponse{}
-	query := query2String(options)
-	path := fmt.Sprintf("/projects%s", query)
-	err := c.requestAndParseResponse("GET", path, nil, res)
-	return res, err
+	return c.GetAllProjectsWithContext(context.Background(), options)
 }
 
-// GetProjectBy returns project by id
-func (c *Client) GetProjectBy(extProjectID string) (*ProjectResponse, error) {
+// GetProjectByWithContext returns project by id
+func (c *Client) GetProjectByWithContext(ctx context.Context, extProjectID string) (*ProjectResponse, error) {
 	err := ValidateNotEmpty(extProjectID)
 	if err != nil {
 		return nil, err
 	}
 	res := &ProjectResponse{}
 	path := fmt.Sprintf("/projects/%s", extProjectID)
-	err = c.requestAndParseResponse("GET", path, nil, res)
+	err = c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
-// GetProjectReport returns a project's report based on observed data from actual panelists.
-func (c *Client) GetProjectReport(extProjectID string) (*ProjectReportResponse, error) {
+// GetProjectBy returns project by id
+func (c *Client) GetProjectBy(extProjectID string) (*ProjectResponse, error) {
+	return c.GetProjectByWithContext(context.Background(), extProjectID)
+}
+
+// GetProjectReportWithContext returns a project's report based on observed data from actual panelists.
+func (c *Client) GetProjectReportWithContext(ctx context.Context, extProjectID string) (*ProjectReportResponse, error) {
 	err := ValidateNotEmpty(extProjectID)
 	if err != nil {
 		return nil, err
 	}
 	res := &ProjectReportResponse{}
 	path := fmt.Sprintf("/projects/%s/report", extProjectID)
-	err = c.requestAndParseResponse("GET", path, nil, res)
+	err = c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
-// AddLineItem ...
-func (c *Client) AddLineItem(extProjectID string, lineItem *CreateLineItemCriteria) (*LineItemResponse, error) {
+// GetProjectReport returns a project's report based on observed data from actual panelists.
+func (c *Client) GetProjectReport(extProjectID string) (*ProjectReportResponse, error) {
+	return c.GetProjectReportWithContext(context.Background(), extProjectID)
+}
+
+// AddLineItemWithContext ...
+func (c *Client) AddLineItemWithContext(ctx context.Context, extProjectID string, lineItem *CreateLineItemCriteria) (*LineItemResponse, error) {
 	err := ValidateNotEmpty(extProjectID)
 	if err != nil {
 		return nil, err
@@ -161,12 +202,17 @@ func (c *Client) AddLineItem(extProjectID string, lineItem *CreateLineItemCriter
 	}
 	res := &LineItemResponse{}
 	path := fmt.Sprintf("/projects/%s/lineItems", extProjectID)
-	err = c.requestAndParseResponse("POST", path, lineItem, res)
+	err = c.requestAndParseResponse(ctx, "POST", path, lineItem, res)
 	return res, err
 }
 
-// UpdateLineItem ...
-func (c *Client) UpdateLineItem(extProjectID, extLineItemID string,
+// AddLineItem ...
+func (c *Client) AddLineItem(extProjectID string, lineItem *CreateLineItemCriteria) (*LineItemResponse, error) {
+	return c.AddLineItemWithContext(context.Background(), extProjectID, lineItem)
+}
+
+// UpdateLineItemWithContext ...
+func (c *Client) UpdateLineItemWithContext(ctx context.Context, extProjectID, extLineItemID string,
 	lineItem *UpdateLineItemCriteria) (*LineItemResponse, error) {
 
 	err := ValidateNotEmpty(extProjectID, extLineItemID)
@@ -183,12 +229,19 @@ func (c *Client) UpdateLineItem(extProjectID, extLineItemID string,
 	}
 	res := &LineItemResponse{}
 	path := fmt.Sprintf("/projects/%s/lineItems/%s", extProjectID, extLineItemID)
-	err = c.requestAndParseResponse("POST", path, lineItem, res)
+	err = c.requestAndParseResponse(ctx, "POST", path, lineItem, res)
 	return res, err
 }
 
-// UpdateLineItemState ... Changes the state of the line item based on provided action.
-func (c *Client) UpdateLineItemState(extProjectID, extLineItemID string, action Action) (
+// UpdateLineItem ...
+func (c *Client) UpdateLineItem(extProjectID, extLineItemID string,
+	lineItem *UpdateLineItemCriteria) (*LineItemResponse, error) {
+
+	return c.UpdateLineItemWithContext(context.Background(), extProjectID, extLineItemID, lineItem)
+}
+
+// UpdateLineItemStateWithContext ... Changes the state of the line item based on provided action.
+func (c *Client) UpdateLineItemStateWithContext(ctx context.Context, extProjectID, extLineItemID string, action Action) (
 	*UpdateLineItemStateResponse, error) {
 	err := ValidateNotEmpty(extProjectID, extLineItemID)
 	if err != nil {
@@ -200,27 +253,48 @@ func (c *Client) UpdateLineItemState(extProjectID, extLineItemID string, action 
 	}
 	res := &UpdateLineItemStateResponse{}
 	path := fmt.Sprintf("/projects/%s/lineItems/%s/%s", extProjectID, extLineItemID, action)
-	err = c.requestAndParseResponse("POST", path, nil, res)
+	err = c.requestAndParseResponse(ctx, "POST", path, nil, res)
 	return res, err
+}
+
+// UpdateLineItemState ... Changes the state of the line item based on provided action.
+func (c *Client) UpdateLineItemState(extProjectID, extLineItemID string, action Action) (
+	*UpdateLineItemStateResponse, error) {
+	return c.UpdateLineItemStateWithContext(context.Background(), extProjectID, extLineItemID, action)
+}
+
+// LaunchLineItemWithContext utility function to launch a line item
+func (c *Client) LaunchLineItemWithContext(ctx context.Context, pid, lid string) (*UpdateLineItemStateResponse, error) {
+	return c.UpdateLineItemStateWithContext(ctx, pid, lid, ActionLaunched)
 }
 
 // LaunchLineItem utility function to launch a line item
 func (c *Client) LaunchLineItem(pid, lid string) (*UpdateLineItemStateResponse, error) {
-	return c.UpdateLineItemState(pid, lid, ActionLaunched)
+	return c.LaunchLineItemWithContext(context.Background(), pid, lid)
+}
+
+// PauseLineItemWithContext utility function to pause a lineitem
+func (c *Client) PauseLineItemWithContext(ctx context.Context, pid, lid string) (*UpdateLineItemStateResponse, error) {
+	return c.UpdateLineItemStateWithContext(ctx, pid, lid, ActionPaused)
 }
 
 // PauseLineItem utility function to pause a lineitem
 func (c *Client) PauseLineItem(pid, lid string) (*UpdateLineItemStateResponse, error) {
-	return c.UpdateLineItemState(pid, lid, ActionPaused)
+	return c.PauseLineItemWithContext(context.Background(), pid, lid)
+}
+
+// CloseLineItemWithContext utility function to close a lineitem
+func (c *Client) CloseLineItemWithContext(ctx context.Context, pid, lid string) (*UpdateLineItemStateResponse, error) {
+	return c.UpdateLineItemStateWithContext(ctx, pid, lid, ActionClosed)
 }
 
 // CloseLineItem utility function to close a lineitem
 func (c *Client) CloseLineItem(pid, lid string) (*UpdateLineItemStateResponse, error) {
-	return c.UpdateLineItemState(pid, lid, ActionClosed)
+	return c.CloseLineItemWithContext(context.Background(), pid, lid)
 }
 
-// SetQuotaCellStatus ... Changes the state of the line item based on provided action.
-func (c *Client) SetQuotaCellStatus(extProjectID, extLineItemID string, quotaCellID string, action Action) (
+// SetQuotaCellStatusWithContext ... Changes the state of the line item based on provided action.
+func (c *Client) SetQuotaCellStatusWithContext(ctx context.Context, extProjectID, extLineItemID string, quotaCellID string, action Action) (
 	*QuotaCellResponse, error) {
 	err := ValidateNotEmpty(extProjectID, extLineItemID, quotaCellID)
 	if err != nil {
@@ -232,31 +306,63 @@ func (c *Client) SetQuotaCellStatus(extProjectID, extLineItemID string, quotaCel
 	}
 	res := &QuotaCellResponse{}
 	path := fmt.Sprintf("/projects/%s/lineItems/%s/quotaCells/%s/%s", extProjectID, extLineItemID, quotaCellID, action)
-	err = c.requestAndParseResponse("POST", path, nil, res)
+	err = c.requestAndParseResponse(ctx, "POST", path, nil, res)
 	return res, err
 }
 
-// GetAllLineItems ...
-func (c *Client) GetAllLineItems(extProjectID string, options *QueryOptions) (*GetAllLineItemsResponse, error) {
+// SetQuotaCellStatus ... Changes the state of the line item based on provided action.
+func (c *Client) SetQuotaCellStatus(extProjectID, extLineItemID string, quotaCellID string, action Action) (
+	*QuotaCellResponse, error) {
+	return c.SetQuotaCellStatusWithContext(context.Background(), extProjectID, extLineItemID, quotaCellID, action)
+}
+
+// GetAllLineItemsWithContext ...
+func (c *Client) GetAllLineItemsWithContext(ctx context.Context, extProjectID string, options *QueryOptions) (*GetAllLineItemsResponse, error) {
 	err := ValidateNotEmpty(extProjectID)
 	if err != nil {
 		return nil, err
 	}
 	res := &GetAllLineItemsResponse{}
 	path := fmt.Sprintf("/projects/%s/lineItems%s", extProjectID, query2String(options))
-	err = c.requestAndParseResponse("GET", path, nil, res)
+	err = c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
-// GetLineItemBy ...
-func (c *Client) GetLineItemBy(extProjectID, extLineItemID string) (*LineItemResponse, error) {
+// GetAllLineItems ...
+func (c *Client) GetAllLineItems(extProjectID string, options *QueryOptions) (*GetAllLineItemsResponse, error) {
+	return c.GetAllLineItemsWithContext(context.Background(), extProjectID, options)
+}
+
+// GetLineItemByWithContext ...
+func (c *Client) GetLineItemByWithContext(ctx context.Context, extProjectID, extLineItemID string) (*LineItemResponse, error) {
 	err := ValidateNotEmpty(extProjectID, extLineItemID)
 	if err != nil {
 		return nil, err
 	}
 	res := &LineItemResponse{}
 	path := fmt.Sprintf("/projects/%s/lineItems/%s", extProjectID, extLineItemID)
-	err = c.requestAndParseResponse("GET", path, nil, res)
+	err = c.requestAndParseResponse(ctx, "GET", path, nil, res)
+	return res, err
+}
+
+// GetLineItemBy ...
+func (c *Client) GetLineItemBy(extProjectID, extLineItemID string) (*LineItemResponse, error) {
+	return c.GetLineItemByWithContext(context.Background(), extProjectID, extLineItemID)
+}
+
+// GetFeasibilityWithContext ... Returns the feasibility for all the line items of the requested project. Takes 20 - 120
+// seconds to execute. Check the `GetFeasibilityResponse.Feasibility.Status` field value to see if it is
+// FeasibilityStatusReady ("READY") or FeasibilityStatusProcessing ("PROCESSING")
+// If GetFeasibilityResponse.Feasibility.Status == FeasibilityStatusProcessing, call this function again in 2 mins.
+func (c *Client) GetFeasibilityWithContext(ctx context.Context, extProjectID string, options *QueryOptions) (*GetFeasibilityResponse, error) {
+	err := ValidateNotEmpty(extProjectID)
+	if err != nil {
+		return nil, err
+	}
+	res := &GetFeasibilityResponse{}
+	path := fmt.Sprintf("/projects/%s/feasibility%s", extProjectID, query2String(options))
+	err = c.requestAndParseResponse(ctx, "GET", path, nil, res)
+
 	return res, err
 }
 
@@ -265,40 +371,47 @@ func (c *Client) GetLineItemBy(extProjectID, extLineItemID string) (*LineItemRes
 // FeasibilityStatusReady ("READY") or FeasibilityStatusProcessing ("PROCESSING")
 // If GetFeasibilityResponse.Feasibility.Status == FeasibilityStatusProcessing, call this function again in 2 mins.
 func (c *Client) GetFeasibility(extProjectID string, options *QueryOptions) (*GetFeasibilityResponse, error) {
-	err := ValidateNotEmpty(extProjectID)
-	if err != nil {
-		return nil, err
-	}
-	res := &GetFeasibilityResponse{}
-	path := fmt.Sprintf("/projects/%s/feasibility%s", extProjectID, query2String(options))
-	err = c.requestAndParseResponse("GET", path, nil, res)
+	return c.GetFeasibilityWithContext(context.Background(), extProjectID, options)
+}
 
-	return res, err
+// GetInvoiceWithContext ... Get the invoice of the requested project
+func (c *Client) GetInvoiceWithContext(ctx context.Context, extProjectID string, options *QueryOptions) (*APIResponse, error) {
+	path := fmt.Sprintf("/projects/%s/invoices", extProjectID)
+	return c.request(ctx, "GET", c.Options.APIBaseURL, path, nil)
 }
 
 // GetInvoice ... Get the invoice of the requested project
 func (c *Client) GetInvoice(extProjectID string, options *QueryOptions) (*APIResponse, error) {
-	path := fmt.Sprintf("/projects/%s/invoices", extProjectID)
-	return c.request("GET", c.Options.APIBaseURL, path, nil)
+	return c.GetInvoiceWithContext(context.Background(), extProjectID, options)
+}
+
+// UploadReconcileWithContext ...  Upload the Request correction file
+func (c *Client) UploadReconcileWithContext(ctx context.Context, extProjectID string, file multipart.File, fileName string, message string, options *QueryOptions) (*APIResponse, error) {
+	path := fmt.Sprintf("/projects/%s/reconcile", extProjectID)
+	res, err := sendFormData(ctx, c.Options.APIBaseURL, "POST", path, c.Auth.AccessToken, file, fileName, message, *c.Options.Timeout)
+	return res, err
 }
 
 // UploadReconcile ...  Upload the Request correction file
 func (c *Client) UploadReconcile(extProjectID string, file multipart.File, fileName string, message string, options *QueryOptions) (*APIResponse, error) {
-	path := fmt.Sprintf("/projects/%s/reconcile", extProjectID)
-	res, err := sendFormData(c.Options.APIBaseURL, "POST", path, c.Auth.AccessToken, file, fileName, message, *c.Options.Timeout)
+	return c.UploadReconcileWithContext(context.Background(), extProjectID, file, fileName, message, options)
+}
+
+// GetCountriesWithContext ... Get the list of supported countries and languages in each country.
+func (c *Client) GetCountriesWithContext(ctx context.Context, options *QueryOptions) (*GetCountriesResponse, error) {
+	res := &GetCountriesResponse{}
+	path := fmt.Sprintf("/countries%s", query2String(options))
+	err := c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
 // GetCountries ... Get the list of supported countries and languages in each country.
 func (c *Client) GetCountries(options *QueryOptions) (*GetCountriesResponse, error) {
-	res := &GetCountriesResponse{}
-	path := fmt.Sprintf("/countries%s", query2String(options))
-	err := c.requestAndParseResponse("GET", path, nil, res)
-	return res, err
+	return c.GetCountriesWithContext(context.Background(), options)
 }
 
-// GetAttributes ... Get the list of supported attributes for a country and language. This data is required to build up the Quota Plan.
-func (c *Client) GetAttributes(countryCode, languageCode string, options *QueryOptions) (*GetAttributesResponse, error) {
+// GetAttributesWithContext ... Get the list of supported attributes for a country and language. This data is required to build up the Quota Plan.
+func (c *Client) GetAttributesWithContext(ctx context.Context, countryCode, languageCode string, options *QueryOptions) (*GetAttributesResponse, error) {
 	err := ValidateNotEmpty(countryCode, languageCode)
 	if err != nil {
 		return nil, err
@@ -313,190 +426,290 @@ func (c *Client) GetAttributes(countryCode, languageCode string, options *QueryO
 	}
 	res := &GetAttributesResponse{}
 	path := fmt.Sprintf("/attributes/%s/%s%s", countryCode, languageCode, query2String(options))
-	err = c.requestAndParseResponse("GET", path, nil, res)
+	err = c.requestAndParseResponse(ctx, "GET", path, nil, res)
+	return res, err
+}
+
+// GetAttributes ... Get the list of supported attributes for a country and language. This data is required to build up the Quota Plan.
+func (c *Client) GetAttributes(countryCode, languageCode string, options *QueryOptions) (*GetAttributesResponse, error) {
+	return c.GetAttributesWithContext(context.Background(), countryCode, languageCode, options)
+}
+
+// GetSurveyTopicsWithContext ... Get the list of supported Survey Topics for a project. This data is required to setup a project.
+func (c *Client) GetSurveyTopicsWithContext(ctx context.Context, options *QueryOptions) (*GetSurveyTopicsResponse, error) {
+	res := &GetSurveyTopicsResponse{}
+	path := fmt.Sprintf("/categories/surveyTopics%s", query2String(options))
+	err := c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
 // GetSurveyTopics ... Get the list of supported Survey Topics for a project. This data is required to setup a project.
 func (c *Client) GetSurveyTopics(options *QueryOptions) (*GetSurveyTopicsResponse, error) {
-	res := &GetSurveyTopicsResponse{}
-	path := fmt.Sprintf("/categories/surveyTopics%s", query2String(options))
-	err := c.requestAndParseResponse("GET", path, nil, res)
+	return c.GetSurveyTopicsWithContext(context.Background(), options)
+}
+
+// GetSourcesWithContext ... Get the list of all the Sample sources
+func (c *Client) GetSourcesWithContext(ctx context.Context, options *QueryOptions) (*GetSampleSourceResponse, error) {
+	res := &GetSampleSourceResponse{}
+	path := fmt.Sprintf("/sources%s", query2String(options))
+	err := c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
 // GetSources ... Get the list of all the Sample sources
 func (c *Client) GetSources(options *QueryOptions) (*GetSampleSourceResponse, error) {
-	res := &GetSampleSourceResponse{}
-	path := fmt.Sprintf("/sources%s", query2String(options))
-	err := c.requestAndParseResponse("GET", path, nil, res)
+	return c.GetSourcesWithContext(context.Background(), options)
+}
+
+// GetEventsWithContext ... Returns the list of all events that have occurred for your company account. Most recent events occur at the top of the list.
+func (c *Client) GetEventsWithContext(ctx context.Context, options *QueryOptions) (*GetEventListResponse, error) {
+	res := &GetEventListResponse{}
+	path := fmt.Sprintf("/events%s", query2String(options))
+	err := c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
 // GetEvents ... Returns the list of all events that have occurred for your company account. Most recent events occur at the top of the list.
 func (c *Client) GetEvents(options *QueryOptions) (*GetEventListResponse, error) {
-	res := &GetEventListResponse{}
-	path := fmt.Sprintf("/events%s", query2String(options))
-	err := c.requestAndParseResponse("GET", path, nil, res)
+	return c.GetEventsWithContext(context.Background(), options)
+}
+
+// GetEventByWithContext ... Returns the requested event based on the eventID
+func (c *Client) GetEventByWithContext(ctx context.Context, eventID string) (*GetEventResponse, error) {
+	res := &GetEventResponse{}
+	path := fmt.Sprintf("/events/%s", eventID)
+	err := c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
 // GetEventBy ... Returns the requested event based on the eventID
 func (c *Client) GetEventBy(eventID string) (*GetEventResponse, error) {
-	res := &GetEventResponse{}
-	path := fmt.Sprintf("/events/%s", eventID)
-	err := c.requestAndParseResponse("GET", path, nil, res)
-	return res, err
+	return c.GetEventByWithContext(context.Background(), eventID)
+}
+
+// AcceptEventWithContext ...
+func (c *Client) AcceptEventWithContext(ctx context.Context, event *Event) error {
+	if event.Actions == nil || len(event.Actions.AcceptURL) == 0 {
+		return ErrEventActionNotApplicable
+	}
+	_, err := c.request(ctx, "POST", event.Actions.AcceptURL, "", nil)
+	return err
 }
 
 // AcceptEvent ...
 func (c *Client) AcceptEvent(event *Event) error {
-	if event.Actions == nil || len(event.Actions.AcceptURL) == 0 {
+	return c.AcceptEventWithContext(context.Background(), event)
+}
+
+// RejectEventWithContext ...
+func (c *Client) RejectEventWithContext(ctx context.Context, event *Event) error {
+	if event.Actions == nil || len(event.Actions.RejectURL) == 0 {
 		return ErrEventActionNotApplicable
 	}
-	_, err := c.request("POST", event.Actions.AcceptURL, "", nil)
+	_, err := c.request(ctx, "POST", event.Actions.RejectURL, "", nil)
 	return err
 }
 
 // RejectEvent ...
 func (c *Client) RejectEvent(event *Event) error {
-	if event.Actions == nil || len(event.Actions.RejectURL) == 0 {
-		return ErrEventActionNotApplicable
-	}
-	_, err := c.request("POST", event.Actions.RejectURL, "", nil)
-	return err
+	return c.RejectEventWithContext(context.Background(), event)
 }
 
-// GetDetailedProjectReport returns a project's detailed report based on observed data from actual panelists.
-func (c *Client) GetDetailedProjectReport(extProjectID string) (*DetailedProjectReportResponse, error) {
+// GetDetailedProjectReportWithContext returns a project's detailed report based on observed data from actual panelists.
+func (c *Client) GetDetailedProjectReportWithContext(ctx context.Context, extProjectID string) (*DetailedProjectReportResponse, error) {
 	err := ValidateNotEmpty(extProjectID)
 	if err != nil {
 		return nil, err
 	}
 	res := &DetailedProjectReportResponse{}
 	path := fmt.Sprintf("/projects/%s/detailedReport", extProjectID)
-	err = c.requestAndParseResponse("GET", path, nil, res)
+	err = c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
-// GetDetailedLineItemReport returns a lineitems's report with quota cell level stats based on observed data from actual panelists.
-func (c *Client) GetDetailedLineItemReport(extProjectID, extLineItemID string) (*DetailedLineItemReportResponse, error) {
+// GetDetailedProjectReport returns a project's detailed report based on observed data from actual panelists.
+func (c *Client) GetDetailedProjectReport(extProjectID string) (*DetailedProjectReportResponse, error) {
+	return c.GetDetailedProjectReportWithContext(context.Background(), extProjectID)
+}
+
+// GetDetailedLineItemReportWithContext returns a lineitems's report with quota cell level stats based on observed data from actual panelists.
+func (c *Client) GetDetailedLineItemReportWithContext(ctx context.Context, extProjectID, extLineItemID string) (*DetailedLineItemReportResponse, error) {
 	err := ValidateNotEmpty(extProjectID)
 	if err != nil {
 		return nil, err
 	}
 	res := &DetailedLineItemReportResponse{}
 	path := fmt.Sprintf("/projects/%s/lineItems/%s/detailedReport", extProjectID, extLineItemID)
-	err = c.requestAndParseResponse("GET", path, nil, res)
+	err = c.requestAndParseResponse(ctx, "GET", path, nil, res)
+	return res, err
+}
+
+// GetDetailedLineItemReport returns a lineitems's report with quota cell level stats based on observed data from actual panelists.
+func (c *Client) GetDetailedLineItemReport(extProjectID, extLineItemID string) (*DetailedLineItemReportResponse, error) {
+	return c.GetDetailedLineItemReportWithContext(context.Background(), extProjectID, extLineItemID)
+}
+
+// GetUserInfoWithContext gives information about the user that is currently logged in.
+func (c *Client) GetUserInfoWithContext(ctx context.Context) (*UserResponse, error) {
+	res := &UserResponse{}
+	path := "/users/info"
+	err := c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
 // GetUserInfo gives information about the user that is currently logged in.
 func (c *Client) GetUserInfo() (*UserResponse, error) {
-	res := &UserResponse{}
-	path := "/users/info"
-	err := c.requestAndParseResponse("GET", path, nil, res)
+	return c.GetUserInfoWithContext(context.Background())
+}
+
+// CompanyUsersWithContext gives information about the user that is currently logged in.
+func (c *Client) CompanyUsersWithContext(ctx context.Context) (*CompanyUsersResponse, error) {
+	res := &CompanyUsersResponse{}
+	path := "/users"
+	err := c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
 // CompanyUsers gives information about the user that is currently logged in.
 func (c *Client) CompanyUsers() (*CompanyUsersResponse, error) {
-	res := &CompanyUsersResponse{}
-	path := "/users"
-	err := c.requestAndParseResponse("GET", path, nil, res)
+	return c.CompanyUsersWithContext(context.Background())
+}
+
+// TeamsInfoWithContext gives information about the user that is currently logged in.
+func (c *Client) TeamsInfoWithContext(ctx context.Context) (*TeamsResponse, error) {
+	res := &TeamsResponse{}
+	path := "/teams"
+	err := c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
 // TeamsInfo gives information about the user that is currently logged in.
 func (c *Client) TeamsInfo() (*TeamsResponse, error) {
-	res := &TeamsResponse{}
-	path := "/teams"
-	err := c.requestAndParseResponse("GET", path, nil, res)
+	return c.TeamsInfoWithContext(context.Background())
+}
+
+// RolesWithContext returns the roles specified in the filter.
+func (c *Client) RolesWithContext(ctx context.Context, options *QueryOptions) (*RolesResponse, error) {
+	res := &RolesResponse{}
+	path := fmt.Sprintf("/roles%s", query2String(options))
+	err := c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
 // Roles returns the roles specified in the filter.
 func (c *Client) Roles(options *QueryOptions) (*RolesResponse, error) {
-	res := &RolesResponse{}
-	path := fmt.Sprintf("/roles%s", query2String(options))
-	err := c.requestAndParseResponse("GET", path, nil, res)
-	return res, err
+	return c.RolesWithContext(context.Background(), options)
 }
 
-// ProjectPermissions gives information about the user that is currently logged in.
-func (c *Client) ProjectPermissions(extProjectID string) (*ProjectPermissionsResponse, error) {
+// ProjectPermissionsWithContext gives information about the user that is currently logged in.
+func (c *Client) ProjectPermissionsWithContext(ctx context.Context, extProjectID string) (*ProjectPermissionsResponse, error) {
 	err := ValidateNotEmpty(extProjectID)
 	if err != nil {
 		return nil, err
 	}
 	res := &ProjectPermissionsResponse{}
 	path := fmt.Sprintf("/projects/%s/permissions", extProjectID)
-	err = c.requestAndParseResponse("GET", path, nil, res)
+	err = c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
-// UpsertProjectPermissions gives information about the user that is currently logged in.
-func (c *Client) UpsertProjectPermissions(permissions *UpsertPermissionsCriteria) (*ProjectPermissionsResponse, error) {
+// ProjectPermissions gives information about the user that is currently logged in.
+func (c *Client) ProjectPermissions(extProjectID string) (*ProjectPermissionsResponse, error) {
+	return c.ProjectPermissionsWithContext(context.Background(), extProjectID)
+}
+
+// UpsertProjectPermissionsWithContext gives information about the user that is currently logged in.
+func (c *Client) UpsertProjectPermissionsWithContext(ctx context.Context, permissions *UpsertPermissionsCriteria) (*ProjectPermissionsResponse, error) {
 	err := Validate(permissions)
 	if err != nil {
 		return nil, err
 	}
 	res := &ProjectPermissionsResponse{}
 	path := fmt.Sprintf("/projects/%s/permissions", permissions.ExtProjectID)
-	err = c.requestAndParseResponse("POST", path, permissions, res)
+	err = c.requestAndParseResponse(ctx, "POST", path, permissions, res)
+	return res, err
+}
+
+// UpsertProjectPermissions gives information about the user that is currently logged in.
+func (c *Client) UpsertProjectPermissions(permissions *UpsertPermissionsCriteria) (*ProjectPermissionsResponse, error) {
+	return c.UpsertProjectPermissionsWithContext(context.Background(), permissions)
+}
+
+// GetStudyMetadataWithContext returns study metadata property info
+func (c *Client) GetStudyMetadataWithContext(ctx context.Context) (*StudyMetadataResponse, error) {
+	res := &StudyMetadataResponse{}
+	path := "/studyMetadata"
+	err := c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
 // GetStudyMetadata returns study metadata property info
 func (c *Client) GetStudyMetadata() (*StudyMetadataResponse, error) {
-	res := &StudyMetadataResponse{}
-	path := "/studyMetadata"
-	err := c.requestAndParseResponse("GET", path, nil, res)
+	return c.GetStudyMetadataWithContext(context.Background())
+}
+
+// CreateTemplateWithContext ...
+func (c *Client) CreateTemplateWithContext(ctx context.Context, template *TemplateCriteria) (*TemplateResponse, error) {
+	err := Validate(template)
+	if err != nil {
+		return nil, err
+	}
+	res := &TemplateResponse{}
+	err = c.requestAndParseResponse(ctx, "POST", "/templates/quotaPlan", template, res)
 	return res, err
 }
 
 // CreateTemplate ...
 func (c *Client) CreateTemplate(template *TemplateCriteria) (*TemplateResponse, error) {
+	return c.CreateTemplateWithContext(context.Background(), template)
+}
+
+// UpdateTemplateWithContext ...
+func (c *Client) UpdateTemplateWithContext(ctx context.Context, id int, template *TemplateCriteria) (*TemplateResponse, error) {
 	err := Validate(template)
 	if err != nil {
 		return nil, err
 	}
 	res := &TemplateResponse{}
-	err = c.requestAndParseResponse("POST", "/templates/quotaPlan", template, res)
+	path := fmt.Sprintf("/templates/quotaPlan/%d", id)
+	err = c.requestAndParseResponse(ctx, "POST", path, template, res)
 	return res, err
 }
 
 // UpdateTemplate ...
 func (c *Client) UpdateTemplate(id int, template *TemplateCriteria) (*TemplateResponse, error) {
-	err := Validate(template)
-	if err != nil {
-		return nil, err
-	}
-	res := &TemplateResponse{}
-	path := fmt.Sprintf("/templates/quotaPlan/%d", id)
-	err = c.requestAndParseResponse("POST", path, template, res)
+	return c.UpdateTemplateWithContext(context.Background(), id, template)
+}
+
+// GetTemplateListWithContext ...
+func (c *Client) GetTemplateListWithContext(ctx context.Context, country string, lang string, options *QueryOptions) (*TemplatesResponse, error) {
+	res := &TemplatesResponse{}
+	query := query2String(options)
+	path := fmt.Sprintf("/templates/quotaPlan/%s/%s%s", country, lang, query)
+	err := c.requestAndParseResponse(ctx, "GET", path, nil, res)
 	return res, err
 }
 
 // GetTemplateList ...
 func (c *Client) GetTemplateList(country string, lang string, options *QueryOptions) (*TemplatesResponse, error) {
-	res := &TemplatesResponse{}
-	query := query2String(options)
-	path := fmt.Sprintf("/templates/quotaPlan/%s/%s%s", country, lang, query)
-	err := c.requestAndParseResponse("GET", path, nil, res)
+	return c.GetTemplateListWithContext(context.Background(), country, lang, options)
+}
+
+// DeleteTemplateWithContext ...
+func (c *Client) DeleteTemplateWithContext(ctx context.Context, id int) (*AppError, error) {
+	res := &AppError{}
+	path := fmt.Sprintf("/templates/quotaPlan/%d", id)
+	err := c.requestAndParseResponse(ctx, "DELETE", path, nil, res)
 	return res, err
 }
 
 // DeleteTemplate ...
 func (c *Client) DeleteTemplate(id int) (*AppError, error) {
-	res := &AppError{}
-	path := fmt.Sprintf("/templates/quotaPlan/%d", id)
-	err := c.requestAndParseResponse("DELETE", path, nil, res)
-	return res, err
+	return c.DeleteTemplateWithContext(context.Background(), id)
 }
 
-// RefreshToken ...
-func (c *Client) RefreshToken() error {
+// RefreshTokenWithContext ...
+func (c *Client) RefreshTokenWithContext(ctx context.Context) error {
 	if c.Auth.RefreshTokenExpired() {
 		return ErrSessionExpired
 	}
@@ -508,7 +721,7 @@ func (c *Client) RefreshToken() error {
 		ClientID:     c.Credentials.ClientID,
 		RefreshToken: c.Auth.RefreshToken,
 	}
-	ar, err := sendRequest(c.Options.AuthURL, "POST", "/token/refresh", "", req, *c.Options.Timeout)
+	ar, err := sendRequest(ctx, c.Options.AuthURL, "POST", "/token/refresh", "", req, *c.Options.Timeout)
 	if err != nil {
 		return err
 	}
@@ -520,8 +733,13 @@ func (c *Client) RefreshToken() error {
 	return nil
 }
 
-// Logout ...
-func (c *Client) Logout() error {
+// RefreshToken ...
+func (c *Client) RefreshToken() error {
+	return c.RefreshTokenWithContext(context.Background())
+}
+
+// LogoutWithContext ...
+func (c *Client) LogoutWithContext(ctx context.Context) error {
 	if c.Auth.AccessTokenExpired() {
 		return nil
 	}
@@ -534,21 +752,31 @@ func (c *Client) Logout() error {
 		RefreshToken: c.Auth.RefreshToken,
 		AccessToken:  c.Auth.AccessToken,
 	}
-	_, err := sendRequest(c.Options.AuthURL, "POST", "/logout", "", req, *c.Options.Timeout)
+	_, err := sendRequest(ctx, c.Options.AuthURL, "POST", "/logout", "", req, *c.Options.Timeout)
 	return err
 }
 
-// GetAuth ...
-func (c *Client) GetAuth() (TokenResponse, error) {
-	err := c.requestAndParseToken()
+// Logout ...
+func (c *Client) Logout() error {
+	return c.LogoutWithContext(context.Background())
+}
+
+// GetAuthWithContext ...
+func (c *Client) GetAuthWithContext(ctx context.Context) (TokenResponse, error) {
+	err := c.requestAndParseToken(ctx)
 	if err != nil {
 		return TokenResponse{}, err
 	}
 	return c.Auth, err
 }
 
-func (c *Client) requestAndParseResponse(method, url string, body interface{}, resObj interface{}) error {
-	ar, err := c.request(method, c.Options.APIBaseURL, url, body)
+// GetAuth ...
+func (c *Client) GetAuth() (TokenResponse, error) {
+	return c.GetAuthWithContext(context.Background())
+}
+
+func (c *Client) requestAndParseResponse(ctx context.Context, method, url string, body interface{}, resObj interface{}) error {
+	ar, err := c.request(ctx, method, c.Options.APIBaseURL, url, body)
 	if err != nil {
 		if ar != nil {
 			json.Unmarshal(ar.Body, &resObj)
@@ -562,27 +790,27 @@ func (c *Client) requestAndParseResponse(method, url string, body interface{}, r
 	return nil
 }
 
-func (c *Client) request(method, host, url string, body interface{}) (*APIResponse, error) {
-	err := c.validateTokens()
+func (c *Client) request(ctx context.Context, method, host, url string, body interface{}) (*APIResponse, error) {
+	err := c.validateTokens(ctx)
 	if err != nil {
 		return nil, err
 	}
-	ar, err := sendRequest(host, method, url, c.Auth.AccessToken, body, *c.Options.Timeout)
+	ar, err := sendRequest(ctx, host, method, url, c.Auth.AccessToken, body, *c.Options.Timeout)
 	errResp, ok := err.(*ErrorResponse)
 	if ok && errResp.HTTPCode == http.StatusUnauthorized {
-		err := c.requestAndParseToken()
+		err := c.requestAndParseToken(ctx)
 		if err != nil {
 			return nil, err
 		}
-		return sendRequest(host, method, url, c.Auth.AccessToken, body, *c.Options.Timeout)
+		return sendRequest(ctx, host, method, url, c.Auth.AccessToken, body, *c.Options.Timeout)
 	}
 	return ar, err
 }
 
-func (c *Client) requestAndParseToken() error {
+func (c *Client) requestAndParseToken(ctx context.Context) error {
 	// log.WithFields(log.Fields{"module": "go-samplifyapi-client", "function": "requestAndParseToken", "ClientID": c.Credentials.ClientID}).Info()
 	t := time.Now()
-	ar, err := sendRequest(c.Options.AuthURL, "POST", "/token/password", "", c.Credentials, *c.Options.Timeout)
+	ar, err := sendRequest(ctx, c.Options.AuthURL, "POST", "/token/password", "", c.Credentials, *c.Options.Timeout)
 	if err != nil {
 		return err
 	}
@@ -595,11 +823,11 @@ func (c *Client) requestAndParseToken() error {
 }
 
 // ValidateTokens ...
-func (c *Client) validateTokens() error {
+func (c *Client) validateTokens(ctx context.Context) error {
 	if c.Auth.AccessTokenExpired() {
-		err := c.RefreshToken()
+		err := c.RefreshTokenWithContext(ctx)
 		if err != nil {
-			err := c.requestAndParseToken()
+			err := c.requestAndParseToken(ctx)
 			if err != nil {
 				return err
 			}
@@ -668,6 +896,6 @@ func NewClientFromEnv(clientID, username, passsword string, env string, timeout 
 }
 
 // GetHealthyStatus ... Get the healthy status on API
-func (c *Client) GetHealthyStatus() (*APIResponse, error) {
-	return c.request("GET", c.Options.GatewayURL, "", nil)
+func (c *Client) GetHealthyStatusWithContext(ctx context.Context) (*APIResponse, error) {
+	return c.request(ctx, "GET", c.Options.GatewayURL, "", nil)
 }


### PR DESCRIPTION
Provides WithContext methods that allow passing context through to the HTTP client. The non-context methods have been updated to use the WithContext methods with the background context.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.