### PR TITLE
remove deprecated requiredCompletes

### DIFF
--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -268,7 +268,6 @@ func getLineItemCriteria() *samplify.CreateLineItemCriteria {
 		IndicativeIncidence: 20.0,
 		DaysInField:         20,
 		LengthOfInterview:   10,
-		RequiredCompletes:   200,
 		SurveyTestingNotes:  &surveyTestingNotesVal,
 		QuotaPlan: &samplify.QuotaPlan{
 			Filters: []*samplify.QuotaFilters{

--- a/lib/line_item.go
+++ b/lib/line_item.go
@@ -131,7 +131,6 @@ type LineItem struct {
 	FieldSchedule       *Schedule         `json:"fieldSchedule"`
 	LengthOfInterview   int64             `json:"lengthOfInterview"`
 	DeliveryType        *string           `json:"deliveryType"`
-	RequiredCompletes   int64             `json:"requiredCompletes"`
 	QuotaPlan           *QuotaPlan        `json:"quotaPlan"`
 	EndLinks            *EndLinks         `json:"endLinks"`
 	SurveyURLParams     []*URLParameter   `json:"surveyURLParams"`
@@ -187,7 +186,6 @@ type CreateLineItemCriteria struct {
 	FieldSchedule       *Schedule         `json:"fieldSchedule" valid:"optional"`
 	LengthOfInterview   int64             `json:"lengthOfInterview" valid:"required"`
 	DeliveryType        *string           `json:"deliveryType" valid:"optional"`
-	RequiredCompletes   int64             `json:"requiredCompletes" valid:"required"`
 	QuotaPlan           *QuotaPlan        `json:"quotaPlan,omitempty" valid:"optional,quotaPlan"`
 	SurveyURLParams     []*URLParameter   `json:"surveyURLParams" valid:"optional"`
 	SurveyTestURLParams []*URLParameter   `json:"surveyTestURLParams" valid:"optional"`
@@ -209,7 +207,6 @@ type UpdateLineItemCriteria struct {
 	FieldSchedule       *Schedule          `json:"fieldSchedule" valid:"optional"`
 	LengthOfInterview   *int64             `json:"lengthOfInterview,omitempty" valid:"optional"`
 	DeliveryType        *string            `json:"deliveryType" valid:"optional"`
-	RequiredCompletes   *int64             `json:"requiredCompletes,omitempty" valid:"optional"`
 	QuotaPlan           *QuotaPlan         `json:"quotaPlan,omitempty" valid:"optional,quotaPlan"`
 	SurveyURLParams     []*URLParameter    `json:"surveyURLParams" valid:"optional"`
 	SurveyTestURLParams []*URLParameter    `json:"surveyTestURLParams" valid:"optional"`


### PR DESCRIPTION
The `requiredCompletes` field was deprecated in the API [February 8, 2019](https://developers.dynata.com/demand-api/changelog#february-8-2019). This changes remove the field, which was required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.